### PR TITLE
Set rootDir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 _build
 _static
 _templates
+src/typechain/*
 typechain/*
 artifacts/*
 cache/solidity-files-cache.json

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install '@ensdomains/dnssecoraclejs' --save
 import { Oracle } from '@ensdomains/dnssecoraclejs'
 const oracle = new Oracle(oracleAddress, provider)
 // Refer to https://github.com/ensdomains/dnsprovejs for how to query result data
-const { data, proof } = oracle.getProofData(result)
+const { rrsets, proof } = oracle.getProofData(result)
 ```
 
 ## Testing

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,5 +10,8 @@ module.exports = {
     hardhat: {
       initialDate: "2021-06-29T00:00:00Z"
     }
+  },
+  typechain: {
+    outDir: "src/typechain",
   }
 };

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "hardhat compile && tsc",

--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -2,8 +2,8 @@ import * as packet from 'dns-packet'
 import * as types from 'dns-packet/types';
 import { utils } from 'ethers';
 import { Provider } from "@ethersproject/providers";
-import { DNSSEC } from '../typechain/DNSSEC';
-import { DNSSEC__factory } from '../typechain/factories/DNSSEC__factory';
+import { DNSSEC } from './typechain/DNSSEC';
+import { DNSSEC__factory } from './typechain/factories/DNSSEC__factory';
 import { ProvableAnswer, SignedSet } from '@ensdomains/dnsprovejs';
 import { logger } from './log'
 
@@ -53,6 +53,7 @@ export class Oracle {
                 };
             }
         }
+        console.log('**** dnssecoraclejs:getProofData')
         logger.info(`${answer.answer.signature.data.typeCovered} ${answer.answer.signature.name} has no proofs already known`);
         return {
             rrsets: this.encodeProofs(allProofs),

--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -53,7 +53,6 @@ export class Oracle {
                 };
             }
         }
-        console.log('**** dnssecoraclejs:getProofData')
         logger.info(`${answer.answer.signature.data.typeCovered} ${answer.answer.signature.name} has no proofs already known`);
         return {
             rrsets: this.encodeProofs(allProofs),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "module": "commonjs",
     "target": "es2015",
     "declaration": true,
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
The current config was compiling under `.`  and moving to `dist` hence it was copying the index file to `dist/src/index.js`. As a result, the npm package import keeps using old files which happened to be `dist/index.js` without being overwritten when compiled.

```
$ls dist/
hardhat.config.d.ts	index.d.ts		log.d.ts		node_modules		oracle.js		test
hardhat.config.js	index.js		log.js			oracle.d.ts		src			typechain
```

This change adds root dir to `src` so that only files under `src` files get copied to `dist`.

```
$ ls dist
index.d.ts	index.js	log.d.ts	log.js		oracle.d.ts	oracle.js	typechain
```



