### PR TITLE
Disable ts logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/dnssecoraclejs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A library for proving DNS records to the ENS DNSSEC oracle contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/dnssecoraclejs",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A library for proving DNS records to the ENS DNSSEC oracle contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/dnssecoraclejs",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A library for proving DNS records to the ENS DNSSEC oracle contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -20,7 +20,7 @@
   "license": "ISC",
   "dependencies": {
     "@ensdomains/dnsprovejs": "^0.3.7",
-    "@ensdomains/ens-contracts": "0.0.5",
+    "@ensdomains/ens-contracts": "0.0.7",
     "dns-packet": "^5.2.1",
     "dotenv": "^8.2.0",
     "ethers": "^5.0.30",

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,8 +1,8 @@
-import {Category,CategoryServiceFactory,CategoryConfiguration,LogLevel} from "typescript-logging";
+// import {Category,CategoryServiceFactory,CategoryConfiguration,LogLevel} from "typescript-logging";
  
-// Optionally change default settings, in this example set default logging to Info.
-// Without changing configuration, categories will log to Error.
-CategoryServiceFactory.setDefaultConfiguration(new CategoryConfiguration(LogLevel.Info));
+// // Optionally change default settings, in this example set default logging to Info.
+// // Without changing configuration, categories will log to Error.
+// CategoryServiceFactory.setDefaultConfiguration(new CategoryConfiguration(LogLevel.Info));
  
-// Create categories, they will autoregister themselves, one category without parent (root) and a child category.
-export const logger = new Category("dnssecoraclejs");
+// // Create categories, they will autoregister themselves, one category without parent (root) and a child category.
+// export const logger = new Category("dnssecoraclejs");

--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -5,7 +5,7 @@ import { Provider } from "@ethersproject/providers";
 import { DNSSEC } from './typechain/DNSSEC';
 import { DNSSEC__factory } from './typechain/factories/DNSSEC__factory';
 import { ProvableAnswer, SignedSet } from '@ensdomains/dnsprovejs';
-import { logger } from './log'
+// import { logger } from './log'
 
 export class OutdatedDataError extends Error {
     answer: SignedSet<any>;
@@ -43,17 +43,17 @@ export class Oracle {
         for(let i = allProofs.length - 1; i >= 0; i--) {
             if(await this.knownProof(allProofs[i])) {
                 if(i == allProofs.length - 1) {
-                    logger.info(`All proofs for ${answer.answer.signature.data.typeCovered} ${answer.answer.signature.name} are already known`);
+                    console.log(`All proofs for ${answer.answer.signature.data.typeCovered} ${answer.answer.signature.name} are already known`);
                     return {rrsets: [], proof: allProofs[allProofs.length - 1].toWire(false)};
                 }
-                logger.info(`${answer.answer.signature.data.typeCovered} ${answer.answer.signature.name} has ${i + 1} of ${allProofs.length} proofs already known`);
+                console.log(`${answer.answer.signature.data.typeCovered} ${answer.answer.signature.name} has ${i + 1} of ${allProofs.length} proofs already known`);
                 return {
                     rrsets: this.encodeProofs(allProofs.slice(i + 1, allProofs.length)),
                     proof: allProofs[i].toWire(false),
                 };
             }
         }
-        logger.info(`${answer.answer.signature.data.typeCovered} ${answer.answer.signature.name} has no proofs already known`);
+        console.log(`${answer.answer.signature.data.typeCovered} ${answer.answer.signature.name} has no proofs already known`);
         return {
             rrsets: this.encodeProofs(allProofs),
             proof: Buffer.from(utils.arrayify(await this.contract.anchors())),


### PR DESCRIPTION
The logger was failing when `ui` import both dnssecoralejs and dnssecoralejs-0-17. I can put it back when removing dnssecoralejs-0-17.